### PR TITLE
Refactor how chat input area hiding works

### DIFF
--- a/chat-monitor.css
+++ b/chat-monitor.css
@@ -24,20 +24,17 @@ textarea.form__input,
 	font-size: 2.4rem !important;
 }
 
-.hide-chat-interface{
+.hide-chat-interface .chat-interface {
 	display:none !important;
 }
 
-.chat-messages {
+.hide-chat-interface .chat-messages {
 	bottom:0px !important;
 }
+
 .tse-content.reverse{
 	height:100%;
 	overflow-y:scroll !important;
-}
-
-.chat-display {
-	height: calc(100% - 111px);
 }
 
 .chat-display-without-interface {

--- a/chat-monitor.js
+++ b/chat-monitor.js
@@ -77,8 +77,7 @@ function actionFunction(){
     }
 
     if(GM_config.get("HideChatInput")) {
-        $( ".chat-interface" ).addClass("hide-chat-interface");
-        $( ".chat-display" ).addClass("chat-display-without-interface");
+        $( ".qa-chat" ).addClass("hide-chat-interface");
     }
 
     // The node to be monitored


### PR DESCRIPTION
I think Twitch changed their class hierarchy since yesterday -- .chat-display no longer seems to exist, at least for me